### PR TITLE
[disturbed-cli] Bump version and appVersion in Chart.yaml

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -24,6 +24,10 @@ jobs:
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          # Workaround as default 4.0.4 doesn't work with python 3.14
+          # See https://github.com/helm/chart-testing-action/issues/177
+          yamale_version: '6.0.0'
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/charts/disturbed-cli/Chart.yaml
+++ b/charts/disturbed-cli/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: disturbed-cli
 description: Disturbed CLI
-version: 0.1.3
-appVersion: 1.0.9
+version: 0.1.4
+appVersion: 1.0.36
 home: https://github.com/hpedrorodrigues/disturbed_cli
 sources:
   - https://github.com/hpedrorodrigues/disturbed_cli


### PR DESCRIPTION
Found this issue: https://github.com/helm/chart-testing-action/issues/177